### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/solidify.js
+++ b/lib/solidify.js
@@ -10,7 +10,7 @@ var Handlebars = require('handlebars'),
     crypto = require('crypto'),
     async = require('async'),
     url = require('url'),
-    ent = require('ent'),
+    he = require('he'),
     winston = require('winston');
 
 var utils = require('./utils.js');
@@ -48,7 +48,7 @@ Solidify.prototype.compile = function (rawTemplate) {
 
         var urls = _.toArray(arguments).slice(m ? 1 : 0),
             options = urls[urls.length - 1];
-        urls = _.map(urls.slice(0, urls.length - 1), ent.decode);
+        urls = _.map(urls.slice(0, urls.length - 1), he.decode);
 
         m = m || 'get';
         reqs[m] = reqs[m] || [];

--- a/package.json
+++ b/package.json
@@ -1,28 +1,36 @@
 {
-    "name": "crawlable-solidify",
-    "version": "1.0.2",
-    "main": "./index.js",
-    "dependencies": {
-        "handlebars": ">=1.0.12",
-        "underscore": ">=1.5.1",
-        "request": ">=2.22.0",
-        "async": ">=0.2.9",
-        "ent": ">=0.0.6",
-        "winston": ">=0.7.2"
-    },
-    "author": {
-        "name": "Theophane Rupin",
-        "email": "theophane.rupin@gmail.com"
-    },
-    "maintainers": ["trupin"],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/trupin/solidify.git"
-    },
-    "description": "Some tools to help you to render your application as a static web site using the crawlable module.",
-    "keywords": ["crawlable", "crawling", "template", "handlebars", "jquery"],
-    "license": "MIT",
-    "engines": {
-        "node": ">=0.4.10"
-    }
+  "name": "crawlable-solidify",
+  "version": "1.0.2",
+  "main": "./index.js",
+  "dependencies": {
+    "async": ">=0.2.9",
+    "handlebars": ">=1.0.12",
+    "he": ">=0.4.1",
+    "request": ">=2.22.0",
+    "underscore": ">=1.5.1",
+    "winston": ">=0.7.2"
+  },
+  "author": {
+    "name": "Theophane Rupin",
+    "email": "theophane.rupin@gmail.com"
+  },
+  "maintainers": [
+    "trupin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trupin/solidify.git"
+  },
+  "description": "Some tools to help you to render your application as a static web site using the crawlable module.",
+  "keywords": [
+    "crawlable",
+    "crawling",
+    "template",
+    "handlebars",
+    "jquery"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.4.10"
+  }
 }


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
